### PR TITLE
Refactor Exolnet\Database\Eloquent\Relations\Helper::syncHasMany.

### DIFF
--- a/src/Exolnet/Database/Eloquent/Relations/Helper.php
+++ b/src/Exolnet/Database/Eloquent/Relations/Helper.php
@@ -1,6 +1,9 @@
-<?php namespace Exolnet\Database\Eloquent\Relations;
+<?php
+
+namespace Exolnet\Database\Eloquent\Relations;
 
 use Closure;
+use DB;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -8,46 +11,54 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 class Helper
 {
 	/**
-	 * @param HasMany  $relation
-	 * @param array    $items
-	 * @param callable $onSave
+	 * @param \Illuminate\Database\Eloquent\Relations\HasMany $relation
+	 * @param array                                           $items
+	 * @param \Closure|null                                   $onSave
 	 */
 	public static function syncHasMany(HasMany $relation, array $items, Closure $onSave = null)
 	{
-		\DB::transaction(function () use ($relation, $items, $onSave) {
+		DB::transaction(function () use ($relation, $items, $onSave) {
 			self::syncHasManyInternal($relation, $items, $onSave);
 		});
 	}
 
+	/**
+	 * @param \Illuminate\Database\Eloquent\Relations\HasMany $relation
+	 * @param array                                           $items
+	 * @param \Closure|null                                   $onSave
+	 */
 	protected static function syncHasManyInternal(HasMany $relation, array $items, Closure $onSave = null)
 	{
-		$updated_keys = [];
-		$new_items = [];
+		$newItems = [];
+		$related = $relation->getRelated();
+		$keyName = $related->getKeyName();
 
-		// 1. Update existing relations and prepare the delete and create steps
+		// 1. Extract all updated keys
+		$updatedKeys = Arr::pluck($items, $keyName);
+
+		// 2. Delete old relations
+		static::deleteAllRelatedExcept($relation, $updatedKeys);
+
+		// 3. Update existing relations
+		$models = $relation->all();
 		foreach ($items as $item) {
-			$model = static::getRelatedModel($relation, $item);
+			$model = $models->find(array_get($item, $keyName));
 
 			if ($model === null) {
-				$new_items[] = $item;
+				$newItems[] = $item;
 				continue;
 			}
 
-			// On met à jour la relation
+			// Update relation data
 			$model->fill($item)->save();
 
 			if ($onSave) {
 				$onSave($model, $item);
 			}
-
-			$updated_keys[] = $model->getKey();
 		}
 
-		// 2. Delete old relations
-		static::deleteAllRelatedExcept($relation, $updated_keys);
-
-		// 3. Create new relations
-		foreach ($new_items as $item) {
+		// 4. Insert new relations
+		foreach ($newItems as $item) {
 			$model = $relation->create($item);
 
 			if ($onSave) {
@@ -57,40 +68,27 @@ class Helper
 	}
 
 	/**
-	 * @param Relation $relation
-	 * @param array    $item
-	 * @return \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|null|static
+	 * @param \Illuminate\Database\Eloquent\Relations\Relation $relation
+	 * @param array                                            $excludedIds
 	 */
-	protected static function getRelatedModel(Relation $relation, array $item)
+	public static function deleteAllRelatedExcept(Relation $relation, $excludedIds = [])
 	{
 		$related = $relation->getRelated();
-		$key_name = $related->getKeyName();
-		$key = array_get($item, $key_name, null);
-
-		if ($key === null) {
-			return null;
-		}
-
-		return $related->find($key);
-	}
-
-	/**
-	 * @param Relation $relation
-	 * @param array    $excluded_ids
-	 */
-	public static function deleteAllRelatedExcept(Relation $relation, $excluded_ids = [])
-	{
-		$related = $relation->getRelated();
-		$key_name = $related->getKeyName();
+		$keyName = $related->getKeyName();
 		$query = $relation->getQuery();
 
-		if (count($excluded_ids) > 0) {
-			$query->whereNotIn($key_name, $excluded_ids);
+		if (count($excludedIds) > 0) {
+			$query->whereNotIn($keyName, $excludedIds);
 		}
 
 		$query->delete();
 	}
 
+	/**
+	 * @param \Illuminate\Database\Eloquent\Relations\BelongsTo $belongsTo
+	 * @param mixed|null                                        $object
+	 * @return mixed
+	 */
 	public static function setBelongsTo(BelongsTo $belongsTo, $object = null)
 	{
 		return $object ? $belongsTo->associate($object) : $belongsTo->dissociate();


### PR DESCRIPTION
Delete all keys not part of the update upfront, query all related models once and then update them. This way, we prevent the fetching of models one by one using Exolnet\Database\Eloquent\Relations\Helper::getRelatedModel.
