### PR TITLE
Add a .gitattributes to all packages directory and in the root folder of the package.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/tests              export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml.dist   export-ignore

--- a/src/Exolnet/Cache/.gitattributes
+++ b/src/Exolnet/Cache/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes     export-ignore
+/README             export-ignore

--- a/src/Exolnet/Core/.gitattributes
+++ b/src/Exolnet/Core/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes     export-ignore
+/README             export-ignore

--- a/src/Exolnet/Database/.gitattributes
+++ b/src/Exolnet/Database/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes     export-ignore
+/README             export-ignore

--- a/src/Exolnet/Extension/.gitattributes
+++ b/src/Exolnet/Extension/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes     export-ignore
+/README             export-ignore

--- a/src/Exolnet/Formatter/.gitattributes
+++ b/src/Exolnet/Formatter/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes     export-ignore
+/README             export-ignore

--- a/src/Exolnet/Foundation/.gitattributes
+++ b/src/Exolnet/Foundation/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes     export-ignore
+/README             export-ignore

--- a/src/Exolnet/Html/.gitattributes
+++ b/src/Exolnet/Html/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes     export-ignore
+/README             export-ignore

--- a/src/Exolnet/Log/.gitattributes
+++ b/src/Exolnet/Log/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes     export-ignore
+/README             export-ignore

--- a/src/Exolnet/Menu/.gitattributes
+++ b/src/Exolnet/Menu/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes     export-ignore
+/README             export-ignore

--- a/src/Exolnet/Routing/.gitattributes
+++ b/src/Exolnet/Routing/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes     export-ignore
+/README             export-ignore

--- a/src/Exolnet/Status/.gitattributes
+++ b/src/Exolnet/Status/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes     export-ignore
+/README             export-ignore

--- a/src/Exolnet/Test/.gitattributes
+++ b/src/Exolnet/Test/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes     export-ignore
+/README             export-ignore

--- a/src/Exolnet/Translation/.gitattributes
+++ b/src/Exolnet/Translation/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes     export-ignore
+/README             export-ignore

--- a/src/Exolnet/User/.gitattributes
+++ b/src/Exolnet/User/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes     export-ignore
+/README             export-ignore

--- a/src/Exolnet/Validation/.gitattributes
+++ b/src/Exolnet/Validation/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes     export-ignore
+/README             export-ignore


### PR DESCRIPTION
The .gitattributes prevents some files from being exported/downloaded as part of the packagist/composer dependency download process.
